### PR TITLE
Apply bugfix in url regex

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -89,8 +89,12 @@ function filterHeaders (headers, filter) {
 }
 
 function buildURL (source = '', reqBase) {
-  // issue ref: https://github.com/fastify/fast-proxy/issues/42
-  const cleanSource = source.replace(/^\/+/g, '/')
+  // issue ref: https://github.com/fastify/fast-proxy/issues/42, https://github.com/fastify/fast-proxy/issues/76
+  let i = 0
+  while (source[i] === '/') {
+    i++
+  }
+  const cleanSource = '/' + source.substring(i)
 
   return new URL(cleanSource, reqBase)
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -90,7 +90,7 @@ function filterHeaders (headers, filter) {
 
 function buildURL (source = '', reqBase) {
   // issue ref: https://github.com/fastify/fast-proxy/issues/42
-  const cleanSource = source.replace(/\/+/g, '/')
+  const cleanSource = source.replace(/^\/+/g, '/')
 
   return new URL(cleanSource, reqBase)
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -94,7 +94,7 @@ function buildURL (source = '', reqBase) {
   while (source[i] === '/') {
     i++
   }
-  const cleanSource = '/' + source.substring(i)
+  const cleanSource = i > 0 ? '/' + source.substring(i) : source
 
   return new URL(cleanSource, reqBase)
 }

--- a/test/10.build-url.test.js
+++ b/test/10.build-url.test.js
@@ -27,6 +27,14 @@ describe('buildURL', () => {
     expect(url.href).to.equal('http://localhost/hi')
   })
 
+  it('should not strip double slashes from query parameters', function () {
+    const url = buildURL('/hi?bye=https%3A//example.com', 'http://localhost')
+
+    expect(url.origin).to.equal('http://localhost')
+    expect(url.pathname).to.equal('/hi')
+    expect(url.href).to.equal('http://localhost/hi?bye=https%3A//example.com')
+  })
+
   it('should produce valid URL (1 param)', function () {
     const url = buildURL('http://localhost/hi')
 


### PR DESCRIPTION
apply [bugfix](https://github.com/fastify/fast-proxy/pull/77) from fastify/fast-proxy to correctly handle consecutive slashes in query parameters