### PR TITLE
fix: security hardening for v1.1.2 — SSRF, header stripping, error disclosure

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function fastProxy (opts = {}) {
         url = getReqUrl(source || req.url, cache, base, opts)
       } catch (err) {
         res.statusCode = 400
-        res.end(err.message)
+        res.end('Bad Request')
         return
       }
       const sourceHttp2 = req.httpVersionMajor === 2

--- a/index.js
+++ b/index.js
@@ -32,7 +32,14 @@ function fastProxy (opts = {}) {
       const rewriteHeaders = opts.rewriteHeaders || rewriteHeadersNoOp
       const rewriteRequestHeaders = opts.rewriteRequestHeaders || rewriteRequestHeadersNoOp
 
-      const url = getReqUrl(source || req.url, cache, base, opts)
+      let url
+      try {
+        url = getReqUrl(source || req.url, cache, base, opts)
+      } catch (err) {
+        res.statusCode = 400
+        res.end(err.message)
+        return
+      }
       const sourceHttp2 = req.httpVersionMajor === 2
       let headers = { ...sourceHttp2 ? filterPseudoHeaders(req.headers) : req.headers }
 
@@ -102,10 +109,10 @@ function fastProxy (opts = {}) {
             err.code === 'UND_ERR_HEADERS_TIMEOUT' ||
             err.code === 'UND_ERR_BODY_TIMEOUT') {
             res.statusCode = 504
-            res.end(err.message)
+            res.end('Gateway Timeout')
           } else {
             res.statusCode = 500
-            res.end(err.message)
+            res.end('Bad Gateway')
           }
 
           return
@@ -114,13 +121,14 @@ function fastProxy (opts = {}) {
         // destructing response from remote
         const { headers, statusCode, stream } = response
 
+        // Strip hop-by-hop headers for all responses (HTTP/1.1 and HTTP/2).
+        // Per RFC 7230 §6.1, hop-by-hop headers MUST NOT be forwarded by proxies.
+        const safeHeaders = stripHttp1ConnectionHeaders(headers)
+
         if (sourceHttp2) {
-          copyHeaders(
-            rewriteHeaders(stripHttp1ConnectionHeaders(headers)),
-            res
-          )
+          copyHeaders(rewriteHeaders(safeHeaders), res)
         } else {
-          copyHeaders(rewriteHeaders(headers), res)
+          copyHeaders(rewriteHeaders(safeHeaders), res)
         }
 
         // set origin response code

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,7 +96,19 @@ function buildURL (source = '', reqBase) {
   }
   const cleanSource = i > 0 ? '/' + source.substring(i) : source
 
-  return new URL(cleanSource, reqBase)
+  const url = new URL(cleanSource, reqBase)
+
+  // SSRF prevention: validate that the resolved URL stays within the
+  // configured base origin. Absolute-form HTTP requests (RFC 7230 §5.3.2)
+  // set req.url to the full URL, which bypasses base via the URL constructor.
+  if (reqBase) {
+    const baseUrl = new URL(reqBase)
+    if (url.origin !== baseUrl.origin) {
+      throw new Error('SSRF prevention: source "' + source + '" resolves to origin "' + url.origin + '" but base origin is "' + baseUrl.origin + '"')
+    }
+  }
+
+  return url
 }
 
 module.exports = {

--- a/test/1.smoke.test.js
+++ b/test/1.smoke.test.js
@@ -121,7 +121,7 @@ describe('fast-proxy smoke', () => {
       .expect(200)
       .then((response) => {
         expect(response.headers['x-agent']).to.equal('fast-proxy')
-        expect(response.headers.host).to.equal('127.0.0.1:3000')
+        // host is a request-only header per RFC 7230, stripped from responses
         expect(response.headers['x-forwarded-host']).to.equal('127.0.0.1:8080')
       })
   })

--- a/test/13.security.test.js
+++ b/test/13.security.test.js
@@ -1,124 +1,124 @@
 /* global describe, it */
-"use strict";
+'use strict'
 
-const { expect } = require("chai");
-const net = require("net");
-const http = require("http");
+const { expect } = require('chai')
+const net = require('net')
+const http = require('http')
 
-describe("Security: buildURL SSRF prevention", () => {
-  const { buildURL } = require("../lib/utils");
+describe('Security: buildURL SSRF prevention', () => {
+  const { buildURL } = require('../lib/utils')
 
-  it("should allow relative paths within base", () => {
-    const url = buildURL("/hi", "http://localhost:3000");
-    expect(url.origin).to.equal("http://localhost:3000");
-  });
+  it('should allow relative paths within base', () => {
+    const url = buildURL('/hi', 'http://localhost:3000')
+    expect(url.origin).to.equal('http://localhost:3000')
+  })
 
-  it("should block absolute URL bypassing base", () => {
-    expect(() => buildURL("http://evil.com/admin", "http://127.0.0.1:3000"))
-      .to.throw(/SSRF prevention/);
-  });
+  it('should block absolute URL bypassing base', () => {
+    expect(() => buildURL('http://evil.com/admin', 'http://127.0.0.1:3000'))
+      .to.throw(/SSRF prevention/)
+  })
 
-  it("should block HTTPS absolute URL bypass", () => {
-    expect(() => buildURL("https://internal/api", "http://127.0.0.1:3000"))
-      .to.throw(/SSRF prevention/);
-  });
+  it('should block HTTPS absolute URL bypass', () => {
+    expect(() => buildURL('https://internal/api', 'http://127.0.0.1:3000'))
+      .to.throw(/SSRF prevention/)
+  })
 
-  it("should allow absolute URL when no base", () => {
-    const url = buildURL("http://target.com/api");
-    expect(url.href).to.equal("http://target.com/api");
-  });
+  it('should allow absolute URL when no base', () => {
+    const url = buildURL('http://target.com/api')
+    expect(url.href).to.equal('http://target.com/api')
+  })
 
-  it("should sanitize protocol-relative within base", () => {
-    const url = buildURL("//evil.com/hi", "http://localhost");
-    expect(url.origin).to.equal("http://localhost");
-  });
-});
+  it('should sanitize protocol-relative within base', () => {
+    const url = buildURL('//evil.com/hi', 'http://localhost')
+    expect(url.origin).to.equal('http://localhost')
+  })
+})
 
-describe("Security: hop-by-hop header stripping", () => {
-  const { stripHttp1ConnectionHeaders } = require("../lib/utils");
+describe('Security: hop-by-hop header stripping', () => {
+  const { stripHttp1ConnectionHeaders } = require('../lib/utils')
 
-  it("should strip transfer-encoding", () => {
-    const h = { "transfer-encoding": "gzip, chunked", "x-custom": "val" };
-    const r = stripHttp1ConnectionHeaders(h);
-    expect(r).to.not.have.property("transfer-encoding");
-    expect(r).to.have.property("x-custom", "val");
-  });
+  it('should strip transfer-encoding', () => {
+    const h = { 'transfer-encoding': 'gzip, chunked', 'x-custom': 'val' }
+    const r = stripHttp1ConnectionHeaders(h)
+    expect(r).to.not.have.property('transfer-encoding')
+    expect(r).to.have.property('x-custom', 'val')
+  })
 
-  it("should strip connection and keep-alive", () => {
-    const h = { connection: "close", "keep-alive": "t=5", "x-data": "ok" };
-    const r = stripHttp1ConnectionHeaders(h);
-    expect(r).to.not.have.property("connection");
-    expect(r).to.not.have.property("keep-alive");
-    expect(r).to.have.property("x-data", "ok");
-  });
+  it('should strip connection and keep-alive', () => {
+    const h = { connection: 'close', 'keep-alive': 't=5', 'x-data': 'ok' }
+    const r = stripHttp1ConnectionHeaders(h)
+    expect(r).to.not.have.property('connection')
+    expect(r).to.not.have.property('keep-alive')
+    expect(r).to.have.property('x-data', 'ok')
+  })
 
-  it("should strip host header from response", () => {
-    const h = { host: "evil.com", "content-type": "text/plain" };
-    const r = stripHttp1ConnectionHeaders(h);
-    expect(r).to.not.have.property("host");
-    expect(r).to.have.property("content-type", "text/plain");
-  });
-});
+  it('should strip host header from response', () => {
+    const h = { host: 'evil.com', 'content-type': 'text/plain' }
+    const r = stripHttp1ConnectionHeaders(h)
+    expect(r).to.not.have.property('host')
+    expect(r).to.have.property('content-type', 'text/plain')
+  })
+})
 
-describe("Security: SSRF end-to-end proxy", () => {
-  let gateway, service, close, proxy, gHttpServer;
+describe('Security: SSRF end-to-end proxy', () => {
+  let gateway, service, close, proxy, gHttpServer
 
-  it("setup", async () => {
-    const fastProxy = require("../index")({ base: "http://127.0.0.1:3000" });
-    close = fastProxy.close;
-    proxy = fastProxy.proxy;
-    gateway = require("restana")();
-    gateway.all("/*", (req, res) => proxy(req, res, req.url, {}));
-    gHttpServer = await gateway.start(8080);
-    service = require("restana")();
-    service.get("/service/get", (req, res) => res.send("OK"));
-    service.get("/service/evil", (req, res) => {
-      res.setHeader("transfer-encoding", "gzip, chunked");
-      res.setHeader("keep-alive", "timeout=99");
-      res.setHeader("x-custom", "downstream");
-      res.end("evil");
-    });
-    await service.start(3000);
-  });
+  it('setup', async () => {
+    const fastProxy = require('../index')({ base: 'http://127.0.0.1:3000' })
+    close = fastProxy.close
+    proxy = fastProxy.proxy
+    gateway = require('restana')()
+    gateway.all('/*', (req, res) => proxy(req, res, req.url, {}))
+    gHttpServer = await gateway.start(8080)
+    service = require('restana')()
+    service.get('/service/get', (req, res) => res.send('OK'))
+    service.get('/service/evil', (req, res) => {
+      res.setHeader('transfer-encoding', 'gzip, chunked')
+      res.setHeader('keep-alive', 'timeout=99')
+      res.setHeader('x-custom', 'downstream')
+      res.end('evil')
+    })
+    await service.start(3000)
+  })
 
-  it("should block SSRF via absolute-form request", (done) => {
+  it('should block SSRF via absolute-form request', (done) => {
     // Use raw http.createServer instead of restana because
     // restana routes cannot match absolute-form req.url values.
-    const fastProxy = require("../index")({ base: "http://127.0.0.1:3000" });
-    const { proxy, close } = fastProxy;
+    const fastProxy = require('../index')({ base: 'http://127.0.0.1:3000' })
+    const { proxy, close } = fastProxy
     const server = http.createServer((req, res) => {
-      proxy(req, res, req.url, {});
-    });
+      proxy(req, res, req.url, {})
+    })
     server.listen(0, () => {
-      const port = server.address().port;
-      const c = net.connect(port, "127.0.0.1", () => {
-        c.write("GET http://169.254.169.254/latest HTTP/1.1\r\n");
-        c.write("Host: 127.0.0.1\r\n");
-        c.write("Connection: close\r\n\r\n");
-      });
-      let d = "";
-      c.on("data", ch => { d += ch.toString(); });
-      c.on("end", () => {
-        expect(d).to.include("400");
+      const port = server.address().port
+      const c = net.connect(port, '127.0.0.1', () => {
+        c.write('GET http://169.254.169.254/latest HTTP/1.1\r\n')
+        c.write('Host: 127.0.0.1\r\n')
+        c.write('Connection: close\r\n\r\n')
+      })
+      let d = ''
+      c.on('data', ch => { d += ch.toString() })
+      c.on('end', () => {
+        expect(d).to.include('400')
         // 400 status + normal proxy still functional after SSRF attempt
-        close();
-        server.close();
-        done();
-      });
-      c.on("error", done);
-    });
-  });it("should strip hop-by-hop headers end-to-end", async () => {
-    const res = await require("supertest")(gHttpServer)
-      .get("/service/evil")
-      .expect(200);
-    expect(res.headers["transfer-encoding"]).to.not.equal("gzip, chunked");
-    expect(res.headers["keep-alive"]).to.not.equal("timeout=99");
-    expect(res.headers["x-custom"]).to.equal("downstream");
-  });
+        close()
+        server.close()
+        done()
+      })
+      c.on('error', done)
+    })
+  }); it('should strip hop-by-hop headers end-to-end', async () => {
+    const res = await require('supertest')(gHttpServer)
+      .get('/service/evil')
+      .expect(200)
+    expect(res.headers['transfer-encoding']).to.not.equal('gzip, chunked')
+    expect(res.headers['keep-alive']).to.not.equal('timeout=99')
+    expect(res.headers['x-custom']).to.equal('downstream')
+  })
 
-  it("teardown", async () => {
-    close();
-    await gateway.close();
-    await service.close();
-  });
-});
+  it('teardown', async () => {
+    close()
+    await gateway.close()
+    await service.close()
+  })
+})

--- a/test/13.security.test.js
+++ b/test/13.security.test.js
@@ -1,0 +1,124 @@
+/* global describe, it */
+"use strict";
+
+const { expect } = require("chai");
+const net = require("net");
+const http = require("http");
+
+describe("Security: buildURL SSRF prevention", () => {
+  const { buildURL } = require("../lib/utils");
+
+  it("should allow relative paths within base", () => {
+    const url = buildURL("/hi", "http://localhost:3000");
+    expect(url.origin).to.equal("http://localhost:3000");
+  });
+
+  it("should block absolute URL bypassing base", () => {
+    expect(() => buildURL("http://evil.com/admin", "http://127.0.0.1:3000"))
+      .to.throw(/SSRF prevention/);
+  });
+
+  it("should block HTTPS absolute URL bypass", () => {
+    expect(() => buildURL("https://internal/api", "http://127.0.0.1:3000"))
+      .to.throw(/SSRF prevention/);
+  });
+
+  it("should allow absolute URL when no base", () => {
+    const url = buildURL("http://target.com/api");
+    expect(url.href).to.equal("http://target.com/api");
+  });
+
+  it("should sanitize protocol-relative within base", () => {
+    const url = buildURL("//evil.com/hi", "http://localhost");
+    expect(url.origin).to.equal("http://localhost");
+  });
+});
+
+describe("Security: hop-by-hop header stripping", () => {
+  const { stripHttp1ConnectionHeaders } = require("../lib/utils");
+
+  it("should strip transfer-encoding", () => {
+    const h = { "transfer-encoding": "gzip, chunked", "x-custom": "val" };
+    const r = stripHttp1ConnectionHeaders(h);
+    expect(r).to.not.have.property("transfer-encoding");
+    expect(r).to.have.property("x-custom", "val");
+  });
+
+  it("should strip connection and keep-alive", () => {
+    const h = { connection: "close", "keep-alive": "t=5", "x-data": "ok" };
+    const r = stripHttp1ConnectionHeaders(h);
+    expect(r).to.not.have.property("connection");
+    expect(r).to.not.have.property("keep-alive");
+    expect(r).to.have.property("x-data", "ok");
+  });
+
+  it("should strip host header from response", () => {
+    const h = { host: "evil.com", "content-type": "text/plain" };
+    const r = stripHttp1ConnectionHeaders(h);
+    expect(r).to.not.have.property("host");
+    expect(r).to.have.property("content-type", "text/plain");
+  });
+});
+
+describe("Security: SSRF end-to-end proxy", () => {
+  let gateway, service, close, proxy, gHttpServer;
+
+  it("setup", async () => {
+    const fastProxy = require("../index")({ base: "http://127.0.0.1:3000" });
+    close = fastProxy.close;
+    proxy = fastProxy.proxy;
+    gateway = require("restana")();
+    gateway.all("/*", (req, res) => proxy(req, res, req.url, {}));
+    gHttpServer = await gateway.start(8080);
+    service = require("restana")();
+    service.get("/service/get", (req, res) => res.send("OK"));
+    service.get("/service/evil", (req, res) => {
+      res.setHeader("transfer-encoding", "gzip, chunked");
+      res.setHeader("keep-alive", "timeout=99");
+      res.setHeader("x-custom", "downstream");
+      res.end("evil");
+    });
+    await service.start(3000);
+  });
+
+  it("should block SSRF via absolute-form request", (done) => {
+    // Use raw http.createServer instead of restana because
+    // restana routes cannot match absolute-form req.url values.
+    const fastProxy = require("../index")({ base: "http://127.0.0.1:3000" });
+    const { proxy, close } = fastProxy;
+    const server = http.createServer((req, res) => {
+      proxy(req, res, req.url, {});
+    });
+    server.listen(0, () => {
+      const port = server.address().port;
+      const c = net.connect(port, "127.0.0.1", () => {
+        c.write("GET http://169.254.169.254/latest HTTP/1.1\r\n");
+        c.write("Host: 127.0.0.1\r\n");
+        c.write("Connection: close\r\n\r\n");
+      });
+      let d = "";
+      c.on("data", ch => { d += ch.toString(); });
+      c.on("end", () => {
+        expect(d).to.include("400");
+        // 400 status + normal proxy still functional after SSRF attempt
+        close();
+        server.close();
+        done();
+      });
+      c.on("error", done);
+    });
+  });it("should strip hop-by-hop headers end-to-end", async () => {
+    const res = await require("supertest")(gHttpServer)
+      .get("/service/evil")
+      .expect(200);
+    expect(res.headers["transfer-encoding"]).to.not.equal("gzip, chunked");
+    expect(res.headers["keep-alive"]).to.not.equal("timeout=99");
+    expect(res.headers["x-custom"]).to.equal("downstream");
+  });
+
+  it("teardown", async () => {
+    close();
+    await gateway.close();
+    await service.close();
+  });
+});


### PR DESCRIPTION
## Summary

Security audit findings and fixes for fast-proxy-lite v1.1.2.

### 🔴 Critical: SSRF via Absolute-Form HTTP Request (CWE-918)

**Finding:** `buildURL()` passes absolute URLs through unchanged when a client sends an absolute-form HTTP request (`GET http://target/path HTTP/1.1`). This bypasses the configured `base` URL entirely, allowing an attacker to force the proxy to forward requests to arbitrary internal targets (AWS metadata, internal services, databases).

**Fix:** Added origin validation in `buildURL()` that throws if the resolved URL's origin differs from the configured base. The `proxy()` function catches this and returns a 400 response.

**PoC:**
```
GET http://169.254.169.254/latest/meta-data/ HTTP/1.1
Host: anything
```
→ Without fix: proxy forwards to AWS metadata service  
→ With fix: returns 400 Bad Request

### 🟡 Medium: Hop-by-Hop Response Header Pass-Through

**Finding:** `stripHttp1ConnectionHeaders()` was only applied for HTTP/2-to-HTTP/1.1 conversions, leaving HTTP/1.1 responses unfiltered. A malicious downstream could inject `transfer-encoding`, `connection`, and `keep-alive` headers that leak to the client.

**Fix:** Apply `stripHttp1ConnectionHeaders()` unconditionally for all response types, per RFC 7230 §6.1.

### 🟢 Low: Error Message Information Disclosure (CWE-209)

**Finding:** Connection errors forwarded raw `err.message` to the client, potentially leaking internal hostnames and network topology.

**Fix:** Replaced with generic messages (`Gateway Timeout`, `Bad Gateway`).

## Changes

| File | Change |
|---|---|
| `lib/utils.js` | Origin validation in `buildURL()` |
| `index.js` | Strip hop-by-hop headers unconditionally; generic error messages; graceful SSRF error handling |
| `test/1.smoke.test.js` | Removed `host` header assertion (request-only per RFC 7230) |
| `test/13.security.test.js` | **NEW** — 12 regression tests covering SSRF and header stripping |

## Verification

All 78 existing + new tests pass:

```
78 passing (3s)
```

## Security tests

```
✓ should allow relative paths within base
✓ should block absolute URL bypassing base
✓ should block HTTPS absolute URL bypass
✓ should allow absolute URL when no base
✓ should sanitize protocol-relative within base
✓ should strip transfer-encoding
✓ should strip connection and keep-alive
✓ should strip host header from response
✓ should block SSRF via absolute-form request
✓ should strip hop-by-hop headers end-to-end
```

Closes audit findings from May 2025 security review.